### PR TITLE
Cirular references detection error in PhantomReporter's stringify function.

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -105,7 +105,7 @@ phantom.sendMessage = function() {
   function stringify(obj) {
     if (typeof obj !== 'object') return obj;
 
-    var cache = [], keyMap = [], tempArray, index;
+    var cache = [], keyMap = [], index;
 
     var string = JSON.stringify(obj, function(key, value) {
       // Let json stringify falsy values
@@ -121,9 +121,6 @@ phantom.sendMessage = function() {
       if (typeof value === 'function') return '[ Function ]';
 
       if (typeof value === 'object' && value !== null) {
-
-        // Check to see if we have a pseudo array that can be converted
-        if (value.length && (tempArray = Array.prototype.slice.call(value)).length === value.length) value = tempArray;
 
         if (index = cache.indexOf(value) !== -1) {
           // If we have it in cache, report the circle with the key we first found it in


### PR DESCRIPTION
The logic which was in place to convert array-like objects to arrays prevented the circular reference detection to work properly for arrays and array-like objects.

`value` can never be found in `cache` (`cache.indexOf(value)` can never be `> -1`), since `value` will always be a newly created array (`tempArray`).

Here is an example of the behavior (before and after the fix): http://jsbin.com/abanur/3/edit

The call to the original function (`stringify`) creates a _"too much recursion"_ error or _"Range Error: Stack size exceeded"_.
