### PR TITLE
bump grunt-lib-phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "~0.1.0",
+    "grunt-lib-phantomjs": "~0.2.0",
     "rimraf": "~2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates dependency to Phantom JS 1.8.1, which among other things, fixes some bugs for us and allows the ability to run on CentOS 5.6 and 5.8.

Note: v0.2.6 was PhantomJS 1.7
