### PR TITLE
Don't delete spec runner on spec fail or if specified directly via options.

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -69,11 +69,15 @@ module.exports = function(grunt) {
 
     var done = this.async();
     phantomRunner(options, function(err,status) {
+      var success = !err && status.failed === 0;
+
       if (err) grunt.log.error(err);
       if (status.failed === 0) grunt.log.ok('0 failures');
       else grunt.log.error(status.failed + ' failures');
+
+      options.keepRunner = options.keepRunner || !success;
       teardown(options);
-      done(!err && status.failed === 0);
+      done(success);
     });
 
   });


### PR DESCRIPTION
I've found useful to keep spec runner html file on spec fail - to be able run it in real browser to investigate the problem. So I've added this ability. Also spec runner could always remain if `options.keepRunner` is `true`.
