### PR TITLE
Ensure the host configuration option has a trailing forward slash so tha...

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -88,6 +88,11 @@ module.exports = function(grunt) {
     var file = options.outfile;
 
     if (options.host) {
+      // Ensure our host URL ends with a forward slash so the outfile doesn't get jammed into the host
+      if (options.host.lastIndexOf('/') !== (options.host.length - 1)) {
+        options.host = options.host + '/';
+      }
+
       file = options.host + options.outfile;
     }
 


### PR DESCRIPTION
...t it does not combined with the host.

Current README does not indicate the host option needs a trailing slash. The current code does not handle this at all. Putting in a host of "http://localhost:8000" for example would cause a timeout. This pull request adds a trailing foward slash if missing.
