### PR TITLE
Allow unlimited # of test suites without warnings

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -116,6 +116,8 @@ module.exports = function(grunt) {
   function setup(options) {
     var thisRun = {};
 
+    // allow as many test suites to be run, as we want
+    phantomjs.setMaxListeners(0);
     phantomjs.on('fail.timeout',function(){
       grunt.log.writeln();
       grunt.warn('PhantomJS timed out, possibly due to an unfinished async spec.', 90);


### PR DESCRIPTION
I'm hacking together an idea for MarionetteJS (Backbone.Marionette) to run my test suite against a number of Backbone and jQuery versions, by looping through a list of each and configuring a jasmine spec setup to run each combination. 

You can see the horrible, ugly idea that I have in place, here: https://github.com/marionettejs/backbone.marionette/blob/testAllThejQueries/Gruntfile.js

The code is nasty, but I plan on cleaning that up once I get things stable enough.

This pull request is needed, to prevent the "too many listeners" warning from occurring, when I have more than 10 jasmine configurations in my gruntfile. It would be nice to not have a limit on the number of jasmine configurations - and though I technically can use as many as I want already, it is a bit unnerving to see the warning message. It tends to give me that sense of "did something break?!" every time I run it.

This change will set the number of event listeners on phantomjs, to unlimited, preventing this error message from occurring.

I realize that setting it to unlimited might be the wrong solution as I'm only treating the symptom. Perhaps there is a way for the design of how this executes to be modified so that the limit is not a problem? I'm not sure - I just found that this was the fastest way to get around the problem, and I wanted to start the discussion.
