### PR TITLE
Fix custom template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ grunt.initConfig({
       src: 'src/**/*.js',
       options: {
         specs: 'spec/*Spec.js',
-        helpers: 'spec/*Helper.js'
+        helpers: 'spec/*Helper.js',
         template: 'custom.tmpl'
       }
     }


### PR DESCRIPTION
There was a missing `,` in the example configuration for supplying the custom template
