### PR TITLE
Swapped forEach out for explicit for loop in reporter for IE compatibility

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -82,9 +82,17 @@ phantom.sendMessage = function() {
     return this.results_[specId];
   };
 
+  function map(values, f) {
+    var result = [];
+    for (var ii = 0; ii < values.length; ii++) {
+      result.push(f(values[ii]));
+    }
+    return result;
+  }
+
   PhantomReporter.prototype.reportRunnerResults = function(runner) {
     this.finished = true;
-    var specIds = runner.specs().map(function(a){return a.id;});
+    var specIds = map(runner.specs(), function(a){return a.id;});
     var summary = this.resultsForSpecs(specIds);
     phantom.sendMessage('jasmine.reportRunnerResults',summary);
     phantom.sendMessage('jasmine.reportJUnitResults', this.generateJUnitSummary(runner));
@@ -218,10 +226,10 @@ phantom.sendMessage = function() {
 
   PhantomReporter.prototype.generateJUnitSummary = function(runner) {
     var consolidatedSuites = {},
-        suites = runner.suites().map(function(suite) {
+        suites = map(runner.suites(), function(suite) {
           var failures = 0;
 
-          var testcases = suite.specs().map(function(spec) {
+          var testcases = map(suite.specs(), function(spec) {
             var failureMessages = [];
             if (spec.results().failedCount) {
               failures++;


### PR DESCRIPTION
This tiny change makes the Jasmine reporter compatible with older browsers (e.g. IE < 9). There are still some warnings that come out later in the process, but this is enough for all tests to be run and an all-green test results page to appear in my suite, whereas without this change IE and similar always break at the end of the first spec.

I know that this is not the core point of this library, but I think there's a reasonable number of other people (e.g. me) who'd like to be able to run quick tests with `grunt jasmine` and then run bigger tests in specific browsers building the same SpecRunner with `jasmine:src:build` occasionally, and this seems worthwhile to make that use case work.

I'd also be happy to put in more changes to take this slightly further and clean up the extra warnings, if there's any interest, but I'm not desperate to push that if that's not something anybody else is interested in.
