### PR TITLE
Teardown now cleans up onAny event

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -103,11 +103,8 @@ module.exports = function(grunt) {
     if (!options.keepRunner && fs.statSync(options.outfile).isFile()) fs.unlink(options.outfile);
     if (!options.keepRunner) jasmine.cleanTemp();
 
-    // Have to explicitly unregister nested wildcards. Need to file a bug for EventEmitter2
-    phantomjs.removeAllListeners('*');
-    phantomjs.removeAllListeners('jasmine.*');
-    phantomjs.removeAllListeners('error.*');
-    phantomjs.removeAllListeners('jasmine.done.*');
+    phantomjs.removeAllListeners();
+    phantomjs.listenersAny().length = 0;
   }
 
   function setup(options) {


### PR DESCRIPTION
Fixes #43.

Did a bit of research and found out it was the `onAny` event not getting cleaned up (https://github.com/gruntjs/grunt-contrib-jasmine/blob/master/tasks/jasmine.js#L149).

The fix gets through @derickbailey's test branch without any errors.

Before:

![image](https://f.cloud.github.com/assets/56288/384388/2732d994-a64e-11e2-9244-5de540d41967.png)

After:

![image](https://f.cloud.github.com/assets/56288/384383/d6b62854-a64d-11e2-9a3e-26ddb5ce483f.png)
