### PR TITLE
Intercepts jasmine.Spec to stringify it as "[ Spec ]" instead of JSON.

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -114,6 +114,11 @@ phantom.sendMessage = function() {
       // If we're a node
       if (value instanceof Node) return '[ Node ]';
 
+      // jasmine-given has expectations on Specs. We intercept to return a
+      // String to avoid stringifying the entire Jasmine environment, which
+      // results in exponential string growth
+      if (value instanceof jasmine.Spec) return '[ Spec: ' + value.description + ' ]';
+
       // If we're a window (logic stolen from jQuery)
       if (value.window && value.window === value.window.window) return '[ Window ]';
 


### PR DESCRIPTION
This is required for using jasmine-given with the reporter, as that library
sets expectations on jasmine.Specs themselves. When the Spec is stringified
as JSON, it ends up stringifying the entire Jasmine environment, including
previous ExpectationResults. Since those previous ExpectationResults have had
their "expected" values stringified, they may include stringified Specs
themselves. This leds to exponential growth in the size of stringified Specs.

Special-casing jasmine.Spec prevents the exponential growth by short-circuting
the value to a small, still-useful String.
