### PR TITLE
Added a filter flag, to filter through the *Spec files

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -54,7 +54,10 @@ module.exports = function(grunt) {
 
     setup(options);
 
-    jasmine.buildSpecrunner(this.filesSrc,options);
+    // The filter returned no spec, let's skip phantom.
+    if(!jasmine.buildSpecrunner(this.filesSrc, options)) {
+      return removePhantomListeners();
+    }
 
     // If we're just building (e.g. for web), skip phantom.
     if (this.flags.build) return;
@@ -100,8 +103,7 @@ module.exports = function(grunt) {
   }
 
   function teardown(options, cb) {
-    phantomjs.removeAllListeners();
-    phantomjs.listenersAny().length = 0;
+    removePhantomListeners();
 
     if (!options.keepRunner && fs.statSync(options.outfile).isFile()) fs.unlink(options.outfile);
     if (!options.keepRunner) {
@@ -109,6 +111,11 @@ module.exports = function(grunt) {
     } else {
       cb();
     }
+  }
+
+  function removePhantomListeners() {
+    phantomjs.removeAllListeners();
+    phantomjs.listenersAny().length = 0;
   }
 
   function setup(options) {


### PR DESCRIPTION
This allows to filter through the *Spec.js files, without having to modify Gruntfile.js

**filename**
`grunt jasmine --filter=foo` will run spec files that have `foo` in their file name.

**folder**
`grunt jasmine --filter=/foo` will run spec files within folders that have `foo*` in their name.

**wildcard**
`grunt jasmine --filter=/*-bar` will run anything that is located in a folder `*-bar`

**comma separated filters**
`grunt jasmine --filter=foo,bar` will run spec files that have `foo` or `bar` in their file name.

**flags with space**
`grunt jasmine --filter="foo bar"` will run spec files that have `foo bar` in their file name.
`grunt jasmine --filter="/foo bar"` will run spec files within folders that have `foo bar*` in their name.

Thoughts? Cheers
