### PR TITLE
PhantomReporter made not to break IE

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -120,7 +120,7 @@ phantom.sendMessage = function() {
       if (!value) return value;
 
       // If we're a node
-      if (value instanceof Node) return '[ Node ]';
+      if (typeof(Node) !== 'undefined' && value instanceof Node) return '[ Node ]';
 
       // jasmine-given has expectations on Specs. We intercept to return a
       // String to avoid stringifying the entire Jasmine environment, which


### PR DESCRIPTION
Current implementation of PhantomReporter breaks IE (that doesn't have `Node` object). Tiny fix to sort it out.
