### PR TITLE
Option to allow task to continue when no specs are found

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -37,7 +37,8 @@ module.exports = function(grunt) {
       host    : '',
       template : __dirname + '/jasmine/templates/DefaultRunner.tmpl',
       templateOptions : {},
-      junit: {}
+      junit: {},
+      ignoreEmpty: grunt.option('force') === true
     });
 
     if (options.template === 'requirejs') {
@@ -209,9 +210,10 @@ module.exports = function(grunt) {
     phantomjs.on('jasmine.reportRunnerResults',function(){
       var dur = (new Date()).getTime() - thisRun.start_time;
       var spec_str = thisRun.executed_specs + (thisRun.executed_specs === 1 ? " spec " : " specs ");
+      var nospec_log = (options.ignoreEmpty) ? grunt.log.error : grunt.warn; //log.error will print the message but not fail the task, warn will do both.
       grunt.verbose.writeln('Runner finished');
       if (thisRun.executed_specs === 0) {
-        grunt.warn('No specs executed, is there a configuration error?');
+        nospec_log.call(null, 'No specs executed, is there a configuration error?');
       }
       if (!grunt.option('verbose')) {
         grunt.log.writeln('');


### PR DESCRIPTION
Currently if you have not yet added your spec file, or if your spec file doesn't have at least one unit test, jasmine will fail with the error message "No specs executed, is there a configuration error?".

This is deliberate:

``` js
if (thisRun.executed_specs === 0) {
    grunt.warn('No specs executed, is there a configuration error?');
}
```

However, if this is part of a series of tasks like a build process, the series of tasks will exit as soon as it hits this, unless you have used the global --force option on the command line.

This change allows you to optionally specify within the task configuration an 'ignoreEmpty' option so that log.error is called rather than warn.  Log.error will output the message but not fail the task.  If ignoreEmpty is not specified, it defaults to whether the force option has been specified on the command line.
