### PR TITLE
PhantomReporter: Testing for Node instance fails when Node is a SocketIO...

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -120,7 +120,7 @@ phantom.sendMessage = function() {
       if (!value) return value;
 
       // If we're a node
-      if (typeof(Node) !== 'undefined' && value instanceof Node) return '[ Node ]';
+      if (typeof(Node) !== 'undefined' && !Node.hasOwnProperty("initialized") && value instanceof Node) return '[ Node ]';
 
       // jasmine-given has expectations on Specs. We intercept to return a
       // String to avoid stringifying the entire Jasmine environment, which


### PR DESCRIPTION
... Object

In recent V8 builds Nodeis defined as a SocketIO object, instanceof on it in line 123 causes a TypeError exception.
The fix added a test to make sure that it is not a SocketIO type of object and make things work again. 
