### PR TITLE
Suppressing of autorunning of specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Default: `false`
 
 Prevents the auto-generated specfile used to run your tests from being automatically deleted.
 
+#### options.run
+Type: `Boolean`  
+Default: `true`  
+
+Instructs phantomjs to run the specfile (when set to `false` and used in combination with `options.keepRunner: true` the task simply generates a specfile that can be opened in the browser)
+
+
 #### options.junit.path
 Type: `String`  
 Default: undefined

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -29,6 +29,7 @@ module.exports = function(grunt) {
     var options = this.options({
       version : '1.3.1',
       timeout : 10000,
+      run: true,
       styles  : [],
       specs   : [],
       helpers : [],
@@ -54,7 +55,7 @@ module.exports = function(grunt) {
     setup(options);
 
     // The filter returned no spec, let's skip phantom.
-    if(!jasmine.buildSpecrunner(this.filesSrc, options)) {
+    if(!jasmine.buildSpecrunner(this.filesSrc, options) || !options.run) {
       return removePhantomListeners();
     }
 


### PR DESCRIPTION
I'm using `grunt-jasmine-istanbul` to generate a specfile with instrumented src files so that when grunt runs my tests it also generates a coverage report. 

But I also want a specfile which contains the original src files, and this specfile should never be run in phantomjs as it's intended purely for debugging in the browser.

My approach is to define two grunt-contrib-jasmine subtasks, one of which uses the istanbul template, and the other the default. The default one I would like to suppress from running in grunt, hence the addition of this `run` option
