### PR TITLE
Export outfile location as part of context

### DIFF
--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -80,6 +80,7 @@ exports.init = function(grunt, phantomjs) {
 
     var context = {
       temp : tempDir,
+      outfile: outfile,
       css  : exports.getRelativeFileList(outdir, jasmineCss, { nonull : true }),
       scripts : {
         polyfills : exports.getRelativeFileList(outdir, polyfills),


### PR DESCRIPTION
[!] It can be accessed by any template

In some cases, for instance, in requirejs template. If spec runner is specified to other locations rather than located in project root (same level with Gruntfile.js), then baseUrl is changed accordingly and needs to be adjusted according to spec runner's new location.

Without this information, requirejs template and any other templates that need that key information can't be aware of where the correct baseUrl is.
