### PR TITLE
New `boot.js` for jasmine 2.0 breaks `requirejs` template

### DIFF
--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -53,7 +53,7 @@ exports.init = function(grunt, phantomjs) {
 
     exports.copyTempFile(__dirname + '/../jasmine/reporters/PhantomReporter.js', 'reporter.js');
 
-    ['jasmine.css', 'jasmine.js', 'jasmine-html.js', 'boot.js'].forEach(function(name){
+    ['jasmine.css', 'jasmine.js', 'jasmine-html.js', 'boot.js', 'start.js'].forEach(function(name){
         var path = __dirname + '/../../vendor/jasmine-' + options.version + '/' + name;
         if (fs.existsSync(path)) exports.copyTempFile(path, name);
     });
@@ -76,7 +76,8 @@ exports.init = function(grunt, phantomjs) {
 
     var jasmineCore = [
       tempDir + '/jasmine.js',
-      tempDir + '/jasmine-html.js'
+      tempDir + '/jasmine-html.js',
+      tempDir + '/boot.js'
     ];
 
     var context = {
@@ -91,7 +92,7 @@ exports.init = function(grunt, phantomjs) {
         src : exports.getRelativeFileList(outdir, src, { nonull : true }),
         vendor : exports.getRelativeFileList(outdir, options.vendor, { nonull : true }),
         reporters : exports.getRelativeFileList(outdir, reporters),
-        boot : exports.getRelativeFileList(outdir, tempDir + '/boot.js')
+        boot : exports.getRelativeFileList(outdir, tempDir + '/start.js')
       },
       options : options.templateOptions || {}
     };

--- a/vendor/jasmine-2.0.0/boot.js
+++ b/vendor/jasmine-2.0.0/boot.js
@@ -105,47 +105,9 @@
   };
 
   /**
-   * ## Runner Parameters
-   *
-   * More browser specific code - wrap the query string in an object and to allow for getting/setting parameters from the runner user interface.
-   */
-
-  var queryString = new jasmine.QueryString({
-    getWindowLocation: function() { return window.location; }
-  });
-
-  var catchingExceptions = queryString.getParam("catch");
-  env.catchExceptions(typeof catchingExceptions === "undefined" ? true : catchingExceptions);
-
-  /**
-   * ## Reporters
-   * The `HtmlReporter` builds all of the HTML UI for the runner page. This reporter paints the dots, stars, and x's for specs, as well as all spec names and all failures (if any).
-   */
-  var htmlReporter = new jasmine.HtmlReporter({
-    env: env,
-    onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
-    getContainer: function() { return document.body; },
-    createElement: function() { return document.createElement.apply(document, arguments); },
-    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
-    timer: new jasmine.Timer()
-  });
-
-  /**
    * The `jsApiReporter` also receives spec results, and is used by any environment that needs to extract the results  from JavaScript.
    */
   env.addReporter(jasmineInterface.jsApiReporter);
-  env.addReporter(htmlReporter);
-
-  /**
-   * Filter which specs will be run by matching the start of the full name against the `spec` query param.
-   */
-  var specFilter = new jasmine.HtmlSpecFilter({
-    filterString: function() { return queryString.getParam("spec"); }
-  });
-
-  env.specFilter = function(spec) {
-    return specFilter.matches(spec.getFullName());
-  };
 
   /**
    * Setting up timing functions to be able to be overridden. Certain browsers (Safari, IE 8, phantomjs) require this hack.
@@ -154,21 +116,6 @@
   window.setInterval = window.setInterval;
   window.clearTimeout = window.clearTimeout;
   window.clearInterval = window.clearInterval;
-
-  /**
-   * ## Execution
-   *
-   * Replace the browser window's `onload`, ensure it's called, and then run all of the loaded specs. This includes initializing the `HtmlReporter` instance and then executing the loaded Jasmine environment. All of this will happen after all of the specs are loaded.
-   */
-  var currentWindowOnload = window.onload;
-
-  window.onload = function() {
-    if (currentWindowOnload) {
-      currentWindowOnload();
-    }
-    htmlReporter.initialize();
-    env.execute();
-  };
 
   /**
    * Helper function for readability above.

--- a/vendor/jasmine-2.0.0/start.js
+++ b/vendor/jasmine-2.0.0/start.js
@@ -1,0 +1,65 @@
+/* global jasmine,window,document */
+(function(env) {
+  /**
+   * ## Runner Parameters
+   *
+   * More browser specific code - wrap the query string in an object and to allow for getting/setting parameters from the runner user interface.
+   */
+
+  var queryString = new jasmine.QueryString({
+    getWindowLocation: function() { return window.location; }
+  });
+
+  var catchingExceptions = queryString.getParam("catch");
+  env.catchExceptions(typeof catchingExceptions === "undefined" ? true : catchingExceptions);
+
+  /**
+   * ## Reporters
+   * The `HtmlReporter` builds all of the HTML UI for the runner page. This reporter paints the dots, stars, and x's for specs, as well as all spec names and all failures (if any).
+   */
+  var htmlReporter = new jasmine.HtmlReporter({
+    env: env,
+    onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
+    getContainer: function() { return document.body; },
+    createElement: function() { return document.createElement.apply(document, arguments); },
+    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
+    timer: new jasmine.Timer()
+  });
+
+  env.addReporter(htmlReporter);
+
+  /**
+   * Filter which specs will be run by matching the start of the full name against the `spec` query param.
+   */
+  var specFilter = new jasmine.HtmlSpecFilter({
+    filterString: function() { return queryString.getParam("spec"); }
+  });
+
+  env.specFilter = function(spec) {
+    return specFilter.matches(spec.getFullName());
+  };
+
+  /**
+   * ## Execution
+   *
+   * Replace the browser window's `onload`, ensure it's called, and then run all of the loaded specs. This includes initializing the `HtmlReporter` instance and then executing the loaded Jasmine environment. All of this will happen after all of the specs are loaded.
+   */
+  function onLoad() {
+    htmlReporter.initialize();
+    env.execute();
+  }
+
+  var currentWindowOnload = window.onload;
+
+  if (document.readyState === 'complete') {
+      onLoad();
+  } else {
+      window.onload = function() {
+        if (currentWindowOnload) {
+          currentWindowOnload();
+        }
+        onLoad();
+      };
+  }
+
+}(jasmine.getEnv()));


### PR DESCRIPTION
`boot.js` isn't pure bootstrap.

Split `boot.js` into 2 separate files
[!] Actually, `boot.js` does 2 kinds of things
1. Expose jasmine API to global env
2. Add reporters and register spec execution callback to window.onload event

This commit simply splits those 2 things to 2 separate files,
then consider first part as a part of jasmine core, the other as bootstrap.

[-] Invoke execute() method directly if document body streaming is closed
