### PR TITLE
Adds istanbul code coverage w/o external template

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,7 @@ module.exports = function(grunt) {
         tasks : ['jasmine:pivotal:build']
       }
     },
+    clean: ['tmp'],
     jasmine: {
       pivotal: {
         src: 'test/fixtures/pivotal/src/**/*.js',
@@ -96,6 +97,17 @@ module.exports = function(grunt) {
           specs:["test/selfTest/*.js"],
           "--web-security": "no"
         }
+      },
+      istanbulTest: {
+        src: 'test/fixtures/pivotal/src/**/*.js',
+        options: {
+          specs: 'test/fixtures/pivotal/spec/*Spec.js',
+          helpers: 'test/fixtures/pivotal/spec/*Helper.js',
+          istanbul: {
+            report:'html',
+            directory:'tmp/istanbul'
+          }
+        }
       }
     },
 
@@ -112,7 +124,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-internal');
   grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-contrib-clean');
 
-  grunt.registerTask('test', ['connect:return500', 'jasmine', 'nodeunit']);
+  grunt.registerTask('test', ['clean','connect:return500', 'jasmine', 'nodeunit']);
   grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);
 };

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Type: `String|Array`
 CSS files that get loaded after the jasmine.css
 
 #### options.version
-Type: `String`  
+Type: `String`
 Default: '2.0.0'
 
 This is the jasmine-version which will be used. currently available versions are:
@@ -87,7 +87,7 @@ This is the jasmine-version which will be used. currently available versions are
 *Due to changes in Jasmine, pre-2.0 versions have been dropped and tracking will resume at 2.0.0*
 
 #### options.outfile
-Type: `String`  
+Type: `String`
 Default: `_SpecRunner.html`
 
 The auto-generated specfile that phantomjs will use to run your tests.
@@ -95,25 +95,25 @@ Automatically deleted upon normal runs. Use the `:build` flag to generate a Spec
 `grunt jasmine:myTask:build`
 
 #### options.keepRunner
-Type: `Boolean`  
-Default: `false`  
+Type: `Boolean`
+Default: `false`
 
 Prevents the auto-generated specfile used to run your tests from being automatically deleted.
 
 #### options.junit.path
-Type: `String`  
+Type: `String`
 Default: undefined
 
 Path to output JUnit xml
 
 #### options.junit.consolidate
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 Consolidate the JUnit XML so that there is one file per top level suite.
 
 #### options.host
-Type: `String`  
+Type: `String`
 Default: ''
 
 The host you want PhantomJS to connect against to run your tests.
@@ -127,7 +127,7 @@ host : 'http://127.0.0.1:8000/'
 Without a `host`, your specs will be run from the local filesystem.
 
 #### options.template
-Type: `String` `Object`  
+Type: `String` `Object`
 Default: undefined
 
 Custom template used to generate your Spec Runner. Parsed as underscore templates and provided
@@ -137,10 +137,34 @@ You can specify an object with a `process` method that will be called as a templ
 See the [Template API Documentation](https://github.com/gruntjs/grunt-contrib-jasmine/wiki/Jasmine-Templates) for more details.
 
 #### options.templateOptions
-Type: `Object`  
+Type: `Object`
 Default: `{}`
 
 Options that will be passed to your template. Used to pass settings to the template.
+
+#### options.istanbul
+Type: `boolean` `Object`
+Default: undefined
+
+Set to `true` or an object with `report` and `directory` properties to turn on code coverage via Istanbul.
+
+#### options.istanbul.report
+Type: `String`
+Default: `text-summary`
+
+The Istanbul report type.  Valid options are `text`, `text-summary`, `html`, `lcov`, `lcovonly`, `cobertura`, or `teamcity`.  The `text` and `text-summary` options will print the coverage report to the console.
+
+#### options.istanbul.directory
+Type: `String`
+Default: `coverage`
+
+The directory where to store the generated Istanbul code coverage report.
+
+#### options.istanbul.instrumenter
+Type: `Object`
+Default: undefined
+
+These options are passed through to the instrumenter from Istanbul.
 
 ### Flags
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "grunt-lib-phantomjs": "~0.4.0",
     "rimraf": "~2.1.4",
     "chalk": "~0.4.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "grunt-lib-istanbul": "~1.0.1"
   },
   "devDependencies": {
     "grunt-contrib-internal": "~0.4.5",
@@ -38,7 +39,8 @@
     "grunt-contrib-jshint": "~0.6.2",
     "grunt": "~0.4.1",
     "grunt-contrib-connect": "~0.4.0",
-    "grunt-contrib-watch": "~0.5.3"
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-clean": "~0.5.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -47,6 +47,9 @@ phantom.sendMessage = function() {
 
   PhantomReporter.prototype.jasmineDone = function() {
     this.finished = true;
+    if (window.__coverage__) {
+        phantom.sendMessage('istanbul.coverage',window.__coverage__);
+    }
     phantom.sendMessage('jasmine.jasmineDone');
     phantom.sendMessage('jasmine.done.PhantomReporter');
   };

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 exports.init = function(grunt, phantomjs) {

--- a/test/jasmine_test.js
+++ b/test/jasmine_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var grunt = require('grunt');
+var fs = require('fs');
 
 // Majority of test benefit comes from running the task itself.
 
@@ -38,6 +39,13 @@ exports.jasmine = {
     var expected = grunt.file.read('./test/expected/defaultTemplate.html');
 
     test.equal(normalize(actual),normalize(expected), 'default test runner template');
+
+    test.done();
+  },
+  istanbulReport: function(test) {
+    test.expect(1);
+
+    test.equal(fs.existsSync('tmp/istanbul/index.html'),true,'should create the istanbul report.');
 
     test.done();
   }


### PR DESCRIPTION
I'm not sure if this is desirable but I wanted to add coverage reports directly to `grunt-contrib-jasmine` w/o needing to configure another library in my Gruntfile.js.  This does that with little effort for config and little overall changes to the code.  

If a user just adds `istanbul:true` to their config like:

``` js
jasmine: {
  mytask: {
    src: [...],
    options: {
      istanbul: true
    }
  }
}
```

The resulting output looks like:

``` shell
Running "jasmine:istanbulTest" (jasmine) task
Testing jasmine specs via PhantomJS

 Player
   ✓ should be able to play a Song
   when song has been paused
     ✓ should indicate that the song is currently paused
     - should be possible to resume...
log: Console logging test
     ✓ should be possible to resume
   ✓ tells the current song if the user has made it a favorite
   #resume
     - should throw an exception if song is already playing...
log: Console logging test
     ✓ should throw an exception if song is already playing

5 specs in 0.112s.
>> 0 failures

=============================== Coverage summary ===============================
Statements   : 93.75% ( 15/16 )
Branches     : 100% ( 2/2 )
Functions    : 85.71% ( 6/7 )
Lines        : 93.75% ( 15/16 )
================================================================================
```
