### PR TITLE
Moved scripts inside the body tag

### DIFF
--- a/tasks/jasmine/templates/DefaultRunner.tmpl
+++ b/tasks/jasmine/templates/DefaultRunner.tmpl
@@ -6,12 +6,13 @@
 <% css.forEach(function(style){ %>
   <link rel="stylesheet" type="text/css" href="<%= style %>">
 <% }) %>
+
+</head>
+<body>
 <% with (scripts) { %>
   <% [].concat(polyfills, jasmine, boot, vendor, helpers, src, specs,reporters).forEach(function(script){ %>
   <script src="<%= script %>"></script>
   <% }) %>
 <% }; %>
-</head>
-<body>
 </body>
 </html>

--- a/test/expected/defaultTemplate.html
+++ b/test/expected/defaultTemplate.html
@@ -6,6 +6,8 @@
 
     <link rel="stylesheet" type="text/css" href="css/a.css">
 
+  </head>
+  <body>
     <script src="p1.js"></script>
     <script src="J1.js"></script>
     <script src="J2.js"></script>
@@ -19,7 +21,5 @@
     <script src="SPEC1.js"></script>
     <script src="SPEC2.js"></script>
     <script src="R1.js"></script>
-  </head>
-  <body>
   </body>
 </html>


### PR DESCRIPTION
Putting scripts as the last item before the closing body tag is these days probably the most common approach to loading scripts in a page, so the jasmine template should arguably follow this convention.

Also this means setup scripts within my src that assume body is present and which run before any specs do will not throw an error
