### PR TITLE
short display of test run results using options.display

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,14 @@ module.exports = function(grunt) {
           specs : 'test/fixtures/phantom-polyfills/spec/**/*.js',
         }
       },
+      consoleDisplayOptions: {
+        src: 'test/fixtures/pivotal/src/**/*.js',
+        options: {
+          specs: 'test/fixtures/pivotal/spec/*Spec.js',
+          helpers: 'test/fixtures/pivotal/spec/*Helper.js',
+          display: 'short',
+        }
+      },
       deepOutfile: {
         src: 'test/fixtures/pivotal/src/**/*.js',
         options: {

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ Default: `{}`
 
 Options that will be passed to your template. Used to pass settings to the template.
 
+#### options.display
+Type: `String`  
+Default: `full`
+
+  * `full` displays the full specs tree
+  * `short` only displays a success or failure character for each test (useful with large suites)
+
 ### Flags
 
 Name: `build`
@@ -266,4 +273,4 @@ for more information on the RequireJS template.
 
 Task submitted by [Jarrod Overson](http://jarrodoverson.com)
 
-*This file was generated on Thu Jan 30 2014 12:26:49.*
+*This file was generated on Wed Feb 26 2014 15:21:40.*

--- a/docs/jasmine-options.md
+++ b/docs/jasmine-options.md
@@ -91,6 +91,13 @@ Default: `{}`
 
 Options that will be passed to your template. Used to pass settings to the template.
 
+## options.display
+Type: `String`  
+Default: `full`
+
+  * `full` displays the full specs tree
+  * `short` only displays a success or failure character for each test (useful with large suites)
+
 # Flags
 
 Name: `build`


### PR DESCRIPTION
When running a very long list of specs, the console output can become unusable (e.g. 1500 tests). To that effect, it would be nice to just get green checkmarks when a test passes, and a red x for failling tests.

This pull requests allows this by providing a 'display' options that takes 'full' (the current and default behavior) and 'short' (the version added in this pull request)

Documentation was updated, tests are green!
