### PR TITLE
v0.5.3 hotfix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-jasmine",
   "description": "Run jasmine specs headlessly through PhantomJS.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "homepage": "https://github.com/gruntjs/grunt-contrib-jasmine",
   "author": {
     "name": "Grunt Team",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "~0.4.0",
+    "grunt-lib-phantomjs": "~0.5.0",
     "rimraf": "~2.1.4"
   },
   "devDependencies": {

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -80,6 +80,7 @@ exports.init = function(grunt, phantomjs) {
 
     var context = {
       temp : tempDir,
+      outfile : outfile,
       css  : exports.getRelativeFileList(outdir, jasmineCss, { nonull : true }),
       scripts : {
         polyfills : exports.getRelativeFileList(outdir, polyfills),


### PR DESCRIPTION
Of course this can't be merged directly into master - but given the incompatibility with `grunt-jasmine-requirejs-template` mentioned in #114, we really could use a v0.5.3 so that those of us using it can upgrade to the latest `grunt-lib-phantomjs` and get the `outfile` fix.

I've kept this in `hotfix` and tagged as v0.5.3 locally - it would be really nice to have that in this repo and published on npm as 0.5.3.
