### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supports AMD tests via the [grunt-template-jasmine-requirejs](https://github.com
 #### src
 Type: `String|Array`
 
-Your source files. These are the files that you are testing.
+Your source files. These are the files that you are testing. If you are using RequireJS your source files will be loaded as dependencies into your spec modules and will not need to be placed here.
 
 #### options.specs
 Type: `String|Array`


### PR DESCRIPTION
Added additional info for the source. When using a requireJS template the source is pulled through requireJS. I found it confusing when people had tried to load a controller in both the src and from their module. This provides better clarification for RequireJS users.
