### PR TITLE
Adding a complex example

### DIFF
--- a/docs/jasmine-examples.md
+++ b/docs/jasmine-examples.md
@@ -42,6 +42,30 @@ grunt.initConfig({
 });
 ```
 
+## Supplying template modules and vendors
+
+A complex version for the above example
+
+```js
+// Example configuration
+grunt.initConfig({
+  jasmine: {
+    customTemplate: {
+      src: 'src/**/*.js',
+      options: {
+        specs: 'spec/*Spec.js',
+        helpers: 'spec/*Helper.js',
+        template: require('exports-process.js')
+        vendor: [
+          "vendor/*.js",
+          "http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"
+        ]
+      }
+    }
+  }
+});
+```
+
 ## Sample RequireJS/NPM Template usage
 
 ```js


### PR DESCRIPTION
For those of us that are new to node, the docs aren't completely clear on what the options do. For example, it's not clear that "vendor" simply drops a script tag into the runner, so one could add external dependencies. And however obvious node modules are, it's important to show a basic use case of them for the custom templates.
