### PR TITLE
suiteDone should reference the suite id in the meta data

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -222,7 +222,7 @@ module.exports = function(grunt) {
     });
 
     phantomjs.on('jasmine.suiteDone', function(suiteMetaData) {
-      suites[currentSuite].time = suiteMetaData.duration / 1000;
+      suites[suiteMetaData.id].time = suiteMetaData.duration / 1000;
       indentLevel--;
     });
 


### PR DESCRIPTION
There is an issue when you have nested test suites.  When suiteDone is called on a parent test suite the time is set for the 'currentSuite' which is actually the last child test suite to run.  Switching this to the test suite in the meta data prevents this issue and allows for the proper creation of junit xml files.
