### PR TITLE
add try/catch for stringify

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -106,11 +106,11 @@ phantom.sendMessage = function() {
             }
             cache.push(value);
             keyMap.push(key);
+          }
         } catch (e) {
             return "[Object]";
         }
-      }
-      return value;
+        return value;
     });
     return string;
   }


### PR DESCRIPTION
In deeply nested object environments and user-defined environements (e.g. overwritten the "Node" class) the stringify method may fail with an exception. 

To avoid these issues I added a try/catch block around the main stringify stuff. It should gracefully default to "[Object]" in these cases where an exception is caught.
