### PR TITLE
Wrapped Failure Message in CDATA

### DIFF
--- a/tasks/jasmine/templates/JUnit.tmpl
+++ b/tasks/jasmine/templates/JUnit.tmpl
@@ -5,7 +5,7 @@
     <% testsuite.testcases.forEach(function(testcase) { %>
       <testcase assertions="<%= testcase.assertions %>" classname="<%- testcase.classname %>" name="<%- testcase.name %>" time="<%= testcase.time %>">
         <% testcase.failureMessages.forEach(function(message) { %>
-          <failure><%= message %></failure>
+          <failure><![CDATA[<%= message %>]]></failure>
         <% }) %>
       </testcase>
     <% }) %>


### PR DESCRIPTION
I think it's wise to wrap the message in `CDATA` since there's a good chance the message will contain XML-like tags.

In my case it was due to one of my failing Angular tests:

```
Expected { $id : '00W', $$childTail : null, $$childHead : null, $$prevSibling : null, $$nextSibling : { $id : '00X', this : <circular reference: Object>, $$listeners : {  }, $$listenerCount : {  }, $parent : { $id : '00V', this : <circular reference: Object>...
```

_(Truncated for sake of sanity)_

In the case of the `<circular reference: Object>`, it was causing the Jenkins job to reject the JUnit XML because it renders an invalid XML document.

With the `CDATA` in place all HTML entities will be nicely escaped, and Jenkins will be happy once again! :+1: 
