### PR TITLE
Fix "Fatal error: Invalid array length" when printing output in a non tty environment

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -296,14 +296,22 @@ module.exports = function(grunt) {
         // If we haven't written out since we've started
         if (thisRun.cleanConsole) {
           // then append to the current line.
-          grunt.log.writeln('...' + symbols[options.display][symbol]);
+          if(options.display === 'full') {
+            grunt.log.writeln('...' + symbols[options.display][symbol]);
+          } else if(options.display === 'short') {
+            grunt.log.write(symbols[options.display][symbol]);
+          }
         } else {
           // Otherwise reprint the current spec and status.
-          grunt.log.writeln(
-            indent(indentLevel) + '...' +
-            chalk.grey(specMetaData.description) + '...' +
-            symbols[options.display][symbol]
-          );
+          if(options.display === 'full') {    
+            grunt.log.writeln(
+              indent(indentLevel) + '...' +
+              chalk.grey(specMetaData.description) + '...' +
+              symbols.full[symbol]
+            );
+          } else if(options.display === 'short') {
+            grunt.log.write(chalk[color].bold(symbols.short[symbol]));
+          }
         }
       }
 


### PR DESCRIPTION
This fix is in response to our current Jenkins integration where jasmine is running without a real terminal.
