### PR TITLE
Update file expand behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ tmp
 tmp
 junit
 .DS_Store
-.grunt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,12 +88,6 @@ module.exports = function(grunt) {
 //          specs: 'test/fixtures/syntaxError/spec/**/*.js'
 //        }
 //      },
-      fileExpand: {
-        src: ['test/fixtures/fileExpand/src/**/*.js', '!test/fixtures/fileExpand/src/exclude.js'],
-        options: {
-          specs: ['test/fixtures/fileExpand/spec/**/*.js', '!test/fixtures/fileExpand/spec/exclude.js']
-        }
-      },
       customTemplate: {
         src: 'test/fixtures/pivotal/src/**/*.js',
         options: {

--- a/test/fixtures/fileExpand/spec/exclude.js
+++ b/test/fixtures/fileExpand/spec/exclude.js
@@ -1,7 +1,0 @@
-describe('fileExpand (excluded spec)', function() {
-
-  it('should exclude spec files', function() {
-    expect(true).not.toBeTruthy();
-  });
-
-});

--- a/test/fixtures/fileExpand/spec/include.js
+++ b/test/fixtures/fileExpand/spec/include.js
@@ -1,8 +1,0 @@
-describe('fileExpand', function() {
-  
-  it('should exclude src files', function() {
-    expect(include).toEqual(true);
-    expect(typeof exclude).toEqual('undefined');
-  });
-
-});

--- a/test/jasmine_test.js
+++ b/test/jasmine_test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var grunt = require('grunt');
+var grunt = require('grunt'),
+    phantomjs = require('grunt-lib-phantomjs').init(grunt),
+    jasmine = require('../tasks/lib/jasmine.js').init(grunt, phantomjs);
 
 // Majority of test benefit comes from running the task itself.
 
@@ -39,6 +41,13 @@ exports.jasmine = {
 
     test.equal(normalize(actual),normalize(expected), 'default test runner template');
 
+    test.done();
+  },
+
+  fileExpand: function(test) {
+    var patterns = ['test/fixtures/fileExpand/src/*.js', '!test/fixtures/fileExpand/src/exclude.js']
+    var expected = ['test/fixtures/fileExpand/src/include.js'];
+    test.deepEqual(jasmine.getRelativeFileList('', patterns, {}), expected, 'should properly expand file list')
     test.done();
   }
 };


### PR DESCRIPTION
`getRelativeFileList` was stepping through patterns rather than passing them all to `grunt.file.expand` leading to exclusions (`!`) being skipped since they remove rather than add files to the list.

Example usage that led to the behavior:

``` js
jasmine: {
  options: {
    specs: ['specs/**/*.js', '!specs/exclude.js']
  }
}

// Before: includes everything in specs, including specs/exclude.js
// After: excludes specs/exclude.js
```
