### PR TITLE
Fix for "Fatal error: Invalid array length"

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -223,7 +223,9 @@ module.exports = function(grunt) {
 
     phantomjs.on('jasmine.suiteDone', function(suiteMetaData) {
       suites[currentSuite].time = suiteMetaData.duration / 1000;
-      indentLevel--;
+      if(indentLevel > 1 ) {
+        indentLevel--;
+      }
     });
 
     phantomjs.on('jasmine.specStarted', function(specMetaData) {


### PR DESCRIPTION
It might happen that the variable `indentLevel` has a negative value which will fail in the function `indent`
