### PR TITLE
Fixes circular reference bug phantom reporter caused by jasmine 2.0.1

### DIFF
--- a/tasks/jasmine/reporters/PhantomReporter.js
+++ b/tasks/jasmine/reporters/PhantomReporter.js
@@ -11,16 +11,16 @@ if (window._phantom) {
   };
 }
 
-phantom.sendMessage = function() {
-  var args = [].slice.call( arguments );
-  var payload = JSON.stringify( args );
-  if (window._phantom) {
-    // alerts are the communication bridge to grunt
-    alert( payload );
-  }
-};
 
 (function(){
+  phantom.sendMessage = function() {
+    var args = [].slice.call( arguments );
+    var payload = stringify( args );
+    if (window._phantom) {
+      // alerts are the communication bridge to grunt
+      alert( payload );
+    }
+  };
 
   function PhantomReporter() {
     this.started = false;


### PR DESCRIPTION
Looks like the jasmine 2.0.1 upgrade caused a circular reference error when the phantom reporter tries to use `JSON.stringify`. I switched it to use the custom `stringify` and it runs in my project. You'll want to check my work however since I don't typically use Phantom to run my tests.
