### PR TITLE
Update es5-shim to latest to remove npm install warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,4 +314,4 @@ for more information on the RequireJS template.
 
 Task submitted by [Jarrod Overson](http://jarrodoverson.com)
 
-*This file was generated on Sat Jul 26 2014 19:28:20.*
+*This file was generated on Sat Aug 02 2014 22:57:46.*

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "rimraf": "~2.1.4",
     "chalk": "~0.4.0",
     "lodash": "~2.4.1",
-    "es5-shim": "~2.3.0"
+    "es5-shim": "~4.0.1"
   },
   "devDependencies": {
     "grunt-contrib-internal": "~0.4.5",


### PR DESCRIPTION
Currently npm install issues a warning about the deprecated es5-shim version. This pr updates to latest es5-shim version.

Example of the warning:
-npm WARN deprecated es5-shim@2.3.0: Please update to the latest version; it overrides noncompliant native methods even in modern implementations
