### PR TITLE
Expose polyfills as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Type: `String|Array`
 
 Non-source, non-spec helper files. In the default runner these are loaded after `vendor` files
 
+#### options.polyfills
+Type: `String|Array`
+
+Third party polyfill libraries like json2 that are loaded at the very top before anything else. es5-shim is loaded automatically with this library.
+
 #### options.styles
 Type: `String|Array`
 
@@ -314,4 +319,4 @@ for more information on the RequireJS template.
 
 Task submitted by [Jarrod Overson](http://jarrodoverson.com)
 
-*This file was generated on Sat Aug 02 2014 22:57:46.*
+*This file was generated on Sun Aug 03 2014 19:28:29.*

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -77,6 +77,7 @@ module.exports = function(grunt) {
       specs : [],
       helpers : [],
       vendor : [],
+      polyfills : [],
       outfile : '_SpecRunner.html',
       host : '',
       template : __dirname + '/jasmine/templates/DefaultRunner.tmpl',

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -72,7 +72,7 @@ exports.init = function(grunt, phantomjs) {
 
     var polyfills = [
       tempDir + '/es5-shim.js'
-    ];
+    ].concat(options.polyfills);
 
     var jasmineCore = [
       tempDir + '/jasmine.js',


### PR DESCRIPTION
By exposing polyfills as a task option, users can provide polyfill libraries such as json2 and querySelector to support old browsers such as IE6 and IE7.
I have pull request https://github.com/pivotal/jasmine/pull/647 with pivotal to fix IE6+7 specific script errors. Once these small changes are merged, then IE6+7 can run Jasmine tests no problem.
