### PR TITLE
add "delay" option

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -80,6 +80,7 @@ module.exports = function(grunt) {
       polyfills : [],
       outfile : '_SpecRunner.html',
       host : '',
+      delay : 0,
       template : __dirname + '/jasmine/templates/DefaultRunner.tmpl',
       templateOptions : {},
       junit : {},
@@ -130,16 +131,32 @@ module.exports = function(grunt) {
       file = options.host + options.outfile;
     }
 
-    grunt.verbose.subhead('Testing jasmine specs via phantom').or.writeln('Testing jasmine specs via PhantomJS');
-    grunt.log.writeln('');
+    var runSpecs = function runSpecs() {
+        grunt.verbose.subhead('Testing jasmine specs via phantom').or.writeln('Testing jasmine specs via PhantomJS');
+        grunt.log.writeln('');
 
-    phantomjs.spawn(file, {
-      failCode : 90,
-      options : options,
-      done : function(err){
-        cb(err,status);
-      }
-    });
+        phantomjs.spawn(file, {
+        failCode : 90,
+        options : options,
+        done : function(err){
+            cb(err,status);
+        }
+        });
+    };
+
+    if (options.delay) {
+        if (typeof options.delay !== 'number' || options.delay < 0) {
+            grunt.fatal('options.delay must be a positive number!');
+        }
+        // wait for specified time before running the specs
+        grunt.log.writeln('Waiting ' + options.delay + ' milliseconds before running jasmine specs...');
+        setTimeout(function() {
+            runSpecs();
+        }, options.delay);
+    } else {
+        runSpecs();
+    }
+
   }
 
   function teardown(options, cb) {


### PR DESCRIPTION
I added a delay config option which allows user to specify waiting time after the spec runner file is built and before it is actually executed. This is useful when the spec runner is not called locally but rather on a remote server to which it is synchronized over rsync or similar tool. The synchronization may take a while, therefore we need to wait before we are able to call it.