### PR TITLE
add open-ended filter pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ watch: {
 **wildcard**
 `grunt jasmine --filter=/*-bar` will run anything that is located in a folder `*-bar`
 
+**open-ended**
+`grunt jasmine --filter=foo/bar` will run spec files with `*foo/bar*` in their path.
+
 **comma separated filters**
 `grunt jasmine --filter=foo,bar` will run spec files that have `foo` or `bar` in their file name.
 

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -159,7 +159,7 @@ exports.init = function(grunt, phantomjs) {
           } else if(pattern.indexOf('/') === 0) {
             specPattern = new RegExp("("+pattern+"[^/]*)(?=/)", "ig");
           } else {
-            throw new TypeError("--filter flag seems to be in the wrong format.");
+            specPattern = new RegExp(pattern, "ig");
           }
 
           // push is usually faster than concat.


### PR DESCRIPTION
I've got a project with similarly named specs (ideas/marquee.spec.js, fww/marquee.spec.js, etc.).  These folders contain other specs as well.  The existing filtering options don't give me enough flexibility to specify a single file.  I've added an open-ended filtering option.  It doesn't interfere with the existing options.