### PR TITLE
clear summary after it has been logged

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -364,6 +364,7 @@ module.exports = function(grunt) {
       if(options.summary && summary.length) {
         grunt.log.writeln();
         logSummary(summary);
+        summary = [];
       }
 
       if (options.junit && options.junit.path) {


### PR DESCRIPTION
Locally `grunt` did not work for me nearly all tests are red. I don't know why I hope it is working on travis :smile:. 
If you want me to add some tests, could you give me pointer where to add it and how to set the development environment. 

This pull request only resets the `summary` array after it has been run. Previously the summaries were kept and all consecutive runs would only add to the old summaries. This fixes #145.