### PR TITLE
Event binding flexibility on PhantomJS instance used by Jasmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Default: `false`
 
 Display a list of all failed tests and their failure messages
 
+#### options.handlers
+Type: `Object`  
+Default: `{}`  
+
+You can attach & listen events on PhantomJS instance used by Jasmine. Pass event names as keys and handling functions as values. It is more handy in situations like you want to sniff the network traffic from PhantomJS whenever a resource is requested and recieved. Here is an example on usage `{onResourceRequested: yourHandler, onResourceReceived: anotherHandler}`
+
 ### Flags
 
 Name: `build`

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -168,7 +168,10 @@ module.exports = function(grunt) {
         tabstop = 2,
         thisRun = {},
         suites = {},
-        currentSuite;
+        currentSuite,
+        optionalHandlers,
+        eventName,
+        handler;
 
     status = {
       failed   : 0
@@ -416,6 +419,12 @@ module.exports = function(grunt) {
       grunt.log.error();
       grunt.warn('PhantomJS unable to load "' + url + '" URI.', 90);
     });
+    
+    optionalHandlers = options.handlers || {};
+    for(eventName in optionalHandlers) {
+        handler = optionalHandlers[eventName];
+        phantomjs.on(eventName, typeof handler === "function" ? handler: function(){});
+    }
   }
 
 };


### PR DESCRIPTION
This comes handy in situations where you want to sniff network traffic of PhantomJS and you want to attach some events to PhantomJS instance.