### PR TITLE
Rolling back dependencies to stabilise the build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "es5-shim": "^4.0.1",
-    "grunt-lib-phantomjs": "^0.7.0",
+    "grunt-lib-phantomjs": "^0.6.0",
     "jasmine-core": "^2.0.4",
-    "lodash": "^3.1.0",
+    "lodash": "~2.4.1",
     "rimraf": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently the master branch is broken unless you roll back to commit d21731e, install and then roll forwards.  Travis CI has been failing since this build https://travis-ci.org/gruntjs/grunt-contrib-jasmine/builds/49943050

The problems are caused by the version bump on grunt-lib-phantomjs and jasmine-core so I've rolled back just those versions and left the rest as it is on master.

To test this fix I've been running `rm -Rf node_modules/ && npm install && npm test` which fails on master and works on this fork/branch/PR.