### PR TITLE
verbose mode with summary option causes crash

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -378,7 +378,7 @@ module.exports = function(grunt) {
     function logSummary(tests) {
         grunt.log.writeln('Summary (' + tests.length + ' tests failed)');
         _.forEach(tests, function(test) {
-            grunt.log.writeln(chalk.red(symbols.options.display.error) + ' ' + test.suite + ' ' + test.name);
+            grunt.log.writeln(chalk.red(symbols[options.display].error) + ' ' + test.suite + ' ' + test.name);
             _.forEach(test.errors, function(error) {
               grunt.log.writeln(indent(2) + chalk.red(error.message));
               logStack(error.stack, 2);


### PR DESCRIPTION
With summary option ON to have verbose stack trace, you crash exception during jasmine validation. This PR will fix this.
symbols is an array, but options.display is not sub element of this array, it's the key to search in symbols.

Thank you