### PR TITLE
Fix bug in logSummary()

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -378,7 +378,7 @@ module.exports = function(grunt) {
     function logSummary(tests) {
         grunt.log.writeln('Summary (' + tests.length + ' tests failed)');
         _.forEach(tests, function(test) {
-            grunt.log.writeln(chalk.red(symbols[options.display]['error']) + ' ' + test.suite + ' ' + test.name);
+            grunt.log.writeln(chalk.red(symbols[options.display].error) + ' ' + test.suite + ' ' + test.name);
             _.forEach(test.errors, function(error) {
               grunt.log.writeln(indent(2) + chalk.red(error.message));
               logStack(error.stack, 2);

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -378,7 +378,7 @@ module.exports = function(grunt) {
     function logSummary(tests) {
         grunt.log.writeln('Summary (' + tests.length + ' tests failed)');
         _.forEach(tests, function(test) {
-            grunt.log.writeln(chalk.red(symbols.options.display.error) + ' ' + test.suite + ' ' + test.name);
+            grunt.log.writeln(chalk.red(symbols[options.display]['error']) + ' ' + test.suite + ' ' + test.name);
             _.forEach(test.errors, function(error) {
               grunt.log.writeln(indent(2) + chalk.red(error.message));
               logStack(error.stack, 2);


### PR DESCRIPTION
With [`options.summary`](https://github.com/gruntjs/grunt-contrib-jasmine/tree/v0.9.0#optionssummary) set to `true`, this fatal error occurs:

```
Summary (1 tests failed)
Fatal error: Cannot read property 'display' of undefined
```

This bug was [introduced](https://github.com/gruntjs/grunt-contrib-jasmine/commit/f5ac86edf27d0eb9cca1bbba910026f532219bbe#diff-4c8c01561530ef0c744c24ba18bf03b1R381) in commit f5ac86e ("Assorted lint fixes") on 23 April 2015. The first affected version is [v0.9.0](https://github.com/gruntjs/grunt-contrib-jasmine/releases/tag/v0.9.0).