### PR TITLE
Add new option: customBootFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ host : 'http://127.0.0.1:8000/'
 
 Without a `host`, your specs will be run from the local filesystem.
 
+#### options.customBootFile
+Type: `String`  
+Default: `lib/jasmine-core/boot.js` from [`jasmine-core`](https://github.com/jasmine/jasmine)
+
+Path to a custom boot file (see the [docs](http://jasmine.github.io/2.3/custom_boot.html)).
+
 #### options.template
 Type: `String` `Object`  
 Default: undefined

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -77,6 +77,7 @@ module.exports = function(grunt) {
       helpers: [],
       vendor: [],
       polyfills: [],
+      customBootFile: null,
       outfile: '_SpecRunner.html',
       host: '',
       template: path.join(__dirname, '/jasmine/templates/DefaultRunner.tmpl'),

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -85,6 +85,12 @@ exports.init = function(grunt, phantomjs) {
       return path.join(tempDir, name);
     });
 
+    var bootFile = tempDir + '/boot.js';
+
+    if (options.customBootFile !== null) {
+      bootFile = options.customBootFile;
+    }
+
     var context = {
       temp: tempDir,
       outfile: outfile,
@@ -97,7 +103,7 @@ exports.init = function(grunt, phantomjs) {
         src: exports.getRelativeFileList(outdir, src, { nonull: true }),
         vendor: exports.getRelativeFileList(outdir, options.vendor, { nonull: true }),
         reporters: exports.getRelativeFileList(outdir, reporters),
-        boot: exports.getRelativeFileList(outdir, tempDir + '/boot.js')
+        boot: exports.getRelativeFileList(outdir, bootFile)
       },
       options: options.templateOptions || {}
     };


### PR DESCRIPTION
I had a need to [customise Jasmine's boot file](http://jasmine.github.io/2.3/custom_boot.html), but I discovered that the path of the file is [hard-coded to `.grunt/grunt-contrib-jasmine/boot.js`](https://github.com/gruntjs/grunt-contrib-jasmine/blob/v0.9.0/tasks/lib/jasmine.js#L100) which is a copy of `node_modules/jasmine-core/lib/jasmine-core/boot.js`.

Here's one solution: a new `customBootFile` option. I've found it useful, and thought it would be worth submitting a PR. What do you think?