### PR TITLE
Remove install dependent path resolution.

### DIFF
--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -65,7 +65,7 @@ exports.init = function(grunt, phantomjs) {
 
     exports.copyTempFile(path.join(jasmineRequire.files.imagesDir, 'jasmine_favicon.png'), 'jasmine_favicon.png');
 
-    exports.copyTempFile(require.resolve( 'es5-shim/es5-shim.js' ), 'es5-shim.js');
+    exports.copyTempFile(require.resolve('es5-shim/es5-shim.js'), 'es5-shim.js');
 
     var reporters = [
       tempDir + '/reporter.js'

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -65,7 +65,7 @@ exports.init = function(grunt, phantomjs) {
 
     exports.copyTempFile(path.join(jasmineRequire.files.imagesDir, 'jasmine_favicon.png'), 'jasmine_favicon.png');
 
-    exports.copyTempFile(path.join(__dirname, '/../../node_modules/es5-shim/es5-shim.js'), 'es5-shim.js');
+    exports.copyTempFile(require.resolve( 'es5-shim/es5-shim.js' ), 'es5-shim.js');
 
     var reporters = [
       tempDir + '/reporter.js'


### PR DESCRIPTION
Removed install dependent path resolution.  The assumption of the package structure limits the usage of this module to only vanilla node.js when it doesn't have to.  By using dynamic resolution other structures may be utilized as well as allowing for the default structure to change without breaking implementation.