### PR TITLE
bump grunt-lib-phantomjs to 1.0.0 (updates phantomjs to 2.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "es5-shim": "^4.0.1",
-    "grunt-lib-phantomjs": "^0.7.1",
+    "grunt-lib-phantomjs": "^1.0.0",
     "jasmine-core": "^2.0.4",
     "lodash": "~2.4.1",
     "rimraf": "^2.1.4"


### PR DESCRIPTION
:tada: PhantomJS 2.1.1  :tada:

https://github.com/gruntjs/grunt-lib-phantomjs/pull/96
https://github.com/Medium/phantomjs/pull/439