### PR TITLE
Stop including `es5-shim`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "es5-shim": "^4.0.1",
     "grunt-lib-phantomjs": "^1.0.0",
     "jasmine-core": "^2.2.0",
     "lodash": "~2.4.1",

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -65,8 +65,6 @@ exports.init = function(grunt, phantomjs) {
 
     exports.copyTempFile(path.join(jasmineRequire.files.imagesDir, 'jasmine_favicon.png'), 'jasmine_favicon.png');
 
-    exports.copyTempFile(require.resolve('es5-shim/es5-shim.js'), 'es5-shim.js');
-
     var reporters = [
       tempDir + '/reporter.js'
     ];
@@ -77,9 +75,7 @@ exports.init = function(grunt, phantomjs) {
 
     jasmineCss = jasmineCss.concat(options.styles);
 
-    var polyfills = [
-      tempDir + '/es5-shim.js'
-    ].concat(options.polyfills);
+    var polyfills = [].concat(options.polyfills);
 
     var jasmineCore = jasmineRequire.files.jsFiles.map(function(name) {
       return path.join(tempDir, name);


### PR DESCRIPTION
PhantomJS 2.x is already ES5 compliant, so no need
to include `es5-shim` anymore.