### PR TITLE
display console.log messages when options.showLogging is set

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,6 +78,15 @@ module.exports = function(grunt) {
           summary: true
         }
       },
+      consoleLoggingOptions: {
+        src: 'test/fixtures/pivotal/src/**/*.js',
+        options: {
+          specs: 'test/fixtures/pivotal/spec/*Spec.js',
+          helpers: 'test/fixtures/pivotal/spec/*Helper.js',
+          display: 'short',
+          showLogging: true
+        }
+      },
       deepOutfile: {
         src: 'test/fixtures/pivotal/src/**/*.js',
         options: {

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Default: `undefined`
 
 Display console logging messages while running tests
 
+Note: setting `options.display` to "full" also enables console logging messages.
+
 #### options.summary
 Type: `Boolean`  
 Default: `false`

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ Default: `'full'`
   * `short` only displays a success or failure character for each test (useful with large suites)
   * `none` displays nothing
 
+#### options.showLogging
+Type: `Boolean`
+Default: `false`
+
+Display console logging messages while running tests
+
 #### options.summary
 Type: `Boolean`  
 Default: `false`

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Default: `'full'`
 
 #### options.showLogging
 Type: `Boolean`
-Default: `false`
+Default: `undefined`
 
 Display console logging messages while running tests
 

--- a/docs/jasmine-options.md
+++ b/docs/jasmine-options.md
@@ -114,7 +114,7 @@ Default: `'full'`
 
 ## options.showLogging
 Type: `Boolean`
-Default: `false`
+Default: `undefined`
 
 Display console logging messages while running tests
 

--- a/docs/jasmine-options.md
+++ b/docs/jasmine-options.md
@@ -112,6 +112,12 @@ Default: `'full'`
   * `short` only displays a success or failure character for each test (useful with large suites)
   * `none` displays nothing
 
+## options.showLogging
+Type: `Boolean`
+Default: `false`
+
+Display console logging messages while running tests
+
 ## options.summary
 Type: `Boolean`  
 Default: `false`

--- a/docs/jasmine-options.md
+++ b/docs/jasmine-options.md
@@ -118,6 +118,8 @@ Default: `undefined`
 
 Display console logging messages while running tests
 
+Note: setting `options.display` to "full" also enables console logging messages.
+
 ## options.summary
 Type: `Boolean`  
 Default: `false`

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -195,7 +195,7 @@ module.exports = function(grunt) {
 
     phantomjs.on('console', function(msg) {
       thisRun.cleanConsole = false;
-      if (options.display === 'full' || options.showLogging) {
+      if (options.showLogging) {
         grunt.log.writeln('\n' + chalk.yellow('log: ') + msg);
       }
     });

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
       ignoreEmpty: grunt.option('force') === true,
       display: 'full',
       summary: false,
-      showLogging: false
+      showLogging: undefined
     });
 
     if (grunt.option('debug')) {

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -194,7 +194,7 @@ module.exports = function(grunt) {
 
     phantomjs.on('console', function(msg) {
       thisRun.cleanConsole = false;
-      if (options.display === 'full') {
+      if (options.display === 'full' || options.showLogging) {
         grunt.log.writeln('\n' + chalk.yellow('log: ') + msg);
       }
     });

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -195,7 +195,9 @@ module.exports = function(grunt) {
 
     phantomjs.on('console', function(msg) {
       thisRun.cleanConsole = false;
-      if (options.showLogging) {
+      // preserve existing behavior of displaying log messages in "full" mode
+      var fullLogging = (typeof(options.showLogging) === 'undefined' && options.display === 'full');
+      if (options.showLogging || fullLogging) {
         grunt.log.writeln('\n' + chalk.yellow('log: ') + msg);
       }
     });

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -86,7 +86,8 @@ module.exports = function(grunt) {
       junit: {},
       ignoreEmpty: grunt.option('force') === true,
       display: 'full',
-      summary: false
+      summary: false,
+      showLogging: false
     });
 
     if (grunt.option('debug')) {


### PR DESCRIPTION
no reason not to include console logging when in "short" mode (which is my preferred default)

example:

```
...
log: Console logging test
...
log: Console logging test
.
```
