### PR TITLE
fix: remove `src` from the DefaultRunner template

### DIFF
--- a/tasks/jasmine/templates/DefaultRunner.tmpl
+++ b/tasks/jasmine/templates/DefaultRunner.tmpl
@@ -11,7 +11,7 @@
 </head>
 <body>
 <% with (scripts) { %>
-  <% [].concat(polyfills, jasmine, boot, vendor, helpers, src, specs,reporters).forEach(function(script){ %>
+  <% [].concat(polyfills, jasmine, boot, vendor, helpers, specs, reporters).forEach(function(script){ %>
   <script src="<%= script %>"></script>
   <% }) %>
 <% }; %>


### PR DESCRIPTION
- removes the `src` option from becoming a script tag which stops
  a 404 when the `_specRunner.html` file is loaded in a browser.

/cc @vladikoff @shama (if you guys aren't the correct folks to ping, I apologize 😁 )