### PR TITLE
Custom temp directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,6 +112,13 @@ module.exports = function(grunt) {
           }
         }
       },
+      customTempDir: {
+        src: 'test/fixtures/custom-temp-dir/src/**/*.js',
+        options: {
+          specs: 'test/fixtures/custom-temp-dir/spec/**/*.js',
+          tempDir: '.custom/'
+        }
+      },
       selfTest: {
         options: {
           specs: ['test/selfTest/*.js'],

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ This is the jasmine-version which will be used. currently available versions are
 
 *Due to changes in Jasmine, pre-2.0 versions have been dropped and tracking will resume at 2.0.0*
 
+#### options.tempDir
+Type: `String`
+Default: `.grunt/grunt-contrib-jasmine`
+
+The temporary directory that runners use to load jasmine files.
+Automatically deleted upon normal runs.
+
 #### options.outfile
 Type: `String`  
 Default: `_SpecRunner.html`
@@ -292,6 +299,27 @@ NPM Templates are just node modules, so you can write and treat them as such.
 Please see the [grunt-template-jasmine-requirejs](https://github.com/jsoverson/grunt-template-jasmine-requirejs) documentation
 for more information on the RequireJS template.
 
+#### Keeping temp files in an existing directory
+
+Supplying a custom temp directory
+
+```js
+// Example configuration
+grunt.initConfig({
+  jasmine: {
+    pivotal: {
+      src: 'src/**/*.js',
+      options: {
+        keepRunner: true,
+        tempDir: 'bin/jasmine/',
+        specs: 'spec/*Spec.js',
+        helpers: 'spec/*Helper.js'
+      }
+    }
+  }
+});
+```
+
 
 ## Release History
 
@@ -329,4 +357,4 @@ for more information on the RequireJS template.
 
 Task submitted by [Jarrod Overson](http://jarrodoverson.com)
 
-*This file was generated on Mon Apr 25 2016 01:03:39.*
+*This file was generated on Tue Jun 14 2016 11:02:35.*

--- a/docs/jasmine-examples.md
+++ b/docs/jasmine-examples.md
@@ -87,3 +87,24 @@ NPM Templates are just node modules, so you can write and treat them as such.
 
 Please see the [grunt-template-jasmine-requirejs](https://github.com/jsoverson/grunt-template-jasmine-requirejs) documentation
 for more information on the RequireJS template.
+
+## Keeping temp files in an existing directory
+
+Supplying a custom temp directory
+
+```js
+// Example configuration
+grunt.initConfig({
+  jasmine: {
+    pivotal: {
+      src: 'src/**/*.js',
+      options: {
+        keepRunner: true,
+        tempDir: 'bin/jasmine/',
+        specs: 'spec/*Spec.js',
+        helpers: 'spec/*Helper.js'
+      }
+    }
+  }
+});
+```

--- a/docs/jasmine-options.md
+++ b/docs/jasmine-options.md
@@ -37,6 +37,13 @@ This is the jasmine-version which will be used. currently available versions are
 
 *Due to changes in Jasmine, pre-2.0 versions have been dropped and tracking will resume at 2.0.0*
 
+## options.tempDir
+Type: `String`
+Default: `.grunt/grunt-contrib-jasmine`
+
+The temporary directory that runners use to load jasmine files.
+Automatically deleted upon normal runs.
+
 ## options.outfile
 Type: `String`  
 Default: `_SpecRunner.html`

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -79,6 +79,7 @@ module.exports = function(grunt) {
       vendor: [],
       polyfills: [],
       customBootFile: null,
+      tempDir: '.grunt/grunt-contrib-jasmine',
       outfile: '_SpecRunner.html',
       host: '',
       template: path.join(__dirname, '/jasmine/templates/DefaultRunner.tmpl'),
@@ -156,7 +157,7 @@ module.exports = function(grunt) {
     }
 
     if (!options.keepRunner) {
-      jasmine.cleanTemp(cb);
+      jasmine.cleanTemp(options.tempDir, cb);
     } else {
       cb();
     }

--- a/tasks/jasmine/templates/DefaultRunner.tmpl
+++ b/tasks/jasmine/templates/DefaultRunner.tmpl
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Jasmine Spec Runner</title>
-  <link rel="shortcut icon" type="image/png" href="<%= temp %>/jasmine_favicon.png">
+  <link rel="shortcut icon" type="image/png" href="<%= favicon %>">
 <% css.forEach(function(style){ %>
   <link rel="stylesheet" type="text/css" href="<%= style %>">
 <% }) %>

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -10,30 +10,33 @@ exports.init = function(grunt, phantomjs) {
       _ = require('lodash'),
       jasmineRequire = require('jasmine-core');
 
-  var baseDir = '.',
-      tempDir = '.grunt/grunt-contrib-jasmine';
+  var baseDir = '.';
 
   var exports = {};
 
   exports.writeTempFile = function(dest, contents) {
-    var file = path.join(tempDir, dest);
-    grunt.file.write(file, contents);
+    grunt.file.write(dest, contents);
   };
 
   exports.copyTempFile = function(src, dest) {
-    var file = path.join(tempDir, dest);
-    grunt.file.copy(src, file);
+    grunt.file.copy(src, dest);
   };
 
-  exports.cleanTemp = function(cb) {
+  exports.cleanTemp = function(tempDir, cb) {
     rimraf(tempDir, function() {
-      // if this fails, then ./.grunt isn't empty and that's ok.
-      fs.rmdir('.grunt', cb);
+      if(tempDir === '.grunt/grunt-contrib-jasmine') {
+        // if this fails, then ./.grunt isn't empty and that's ok.
+        fs.rmdir('.grunt', cb);
+      } else {
+        // don't delete parent directory of a custom directory.
+        cb();
+      }
     });
   };
 
   exports.buildSpecrunner = function(src, options) {
     var source = '',
+      tempDir = options.tempDir,
       outfile = options.outfile,
       specrunner = path.join(baseDir, outfile),
       outdir = path.dirname(outfile),
@@ -51,19 +54,19 @@ exports.init = function(grunt, phantomjs) {
       }
     }
 
-    exports.copyTempFile(path.join(__dirname, '/../jasmine/reporters/PhantomReporter.js'), 'reporter.js');
+    exports.copyTempFile(path.join(__dirname, '/../jasmine/reporters/PhantomReporter.js'), path.join(tempDir, 'reporter.js'));
 
     [].concat(jasmineRequire.files.cssFiles, jasmineRequire.files.jsFiles).forEach(function(name) {
       var srcPath = path.join(jasmineRequire.files.path, name);
-      exports.copyTempFile(srcPath, name);
+      exports.copyTempFile(srcPath, path.join(tempDir, name));
     });
 
     jasmineRequire.files.bootFiles.forEach(function(name) {
       var srcPath = path.join(jasmineRequire.files.bootDir, name);
-      exports.copyTempFile(srcPath, name);
+      exports.copyTempFile(srcPath, path.join(tempDir, name));
     });
 
-    exports.copyTempFile(path.join(jasmineRequire.files.imagesDir, 'jasmine_favicon.png'), 'jasmine_favicon.png');
+    exports.copyTempFile(path.join(jasmineRequire.files.imagesDir, 'jasmine_favicon.png'), path.join(tempDir, 'jasmine_favicon.png'));
 
     var reporters = [
       tempDir + '/reporter.js'

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -93,6 +93,7 @@ exports.init = function(grunt, phantomjs) {
     var context = {
       temp: tempDir,
       outfile: outfile,
+      favicon: path.join(tempDir, 'jasmine_favicon.png'),
       css: exports.getRelativeFileList(outdir, jasmineCss, { nonull: true }),
       scripts: {
         polyfills: exports.getRelativeFileList(outdir, polyfills),

--- a/test/fixtures/custom-temp-dir/spec/test-spec.js
+++ b/test/fixtures/custom-temp-dir/spec/test-spec.js
@@ -1,0 +1,20 @@
+describe("custom temp directory test", function() {
+
+  it("should have loaded from a custom temp directory", function() {
+    expect(working).toBeTruthy();
+
+    var links = document.getElementsByTagName('link');
+    expect(links[0].href).toEqual(jasmine.stringMatching('.custom/jasmine_favicon.png'));
+    expect(links[1].href).toEqual(jasmine.stringMatching('.custom/jasmine.css'));
+
+    var scripts = document.getElementsByTagName('script');
+    expect(scripts[0].src).toEqual(jasmine.stringMatching('.custom/jasmine.js'));
+    expect(scripts[1].src).toEqual(jasmine.stringMatching('.custom/jasmine-html.js'));
+    expect(scripts[2].src).toEqual(jasmine.stringMatching('.custom/json2.js'));
+    expect(scripts[3].src).toEqual(jasmine.stringMatching('.custom/boot.js'));
+    expect(scripts[4].src).toEqual(jasmine.stringMatching('test/fixtures/custom-temp-dir/src/test.js'));
+    expect(scripts[5].src).toEqual(jasmine.stringMatching('test/fixtures/custom-temp-dir/spec/test-spec.js'));
+    expect(scripts[6].src).toEqual(jasmine.stringMatching('.custom/reporter.js'));
+  });
+
+});

--- a/test/fixtures/custom-temp-dir/src/test.js
+++ b/test/fixtures/custom-temp-dir/src/test.js
@@ -1,0 +1,1 @@
+working = true

--- a/test/jasmine_test.js
+++ b/test/jasmine_test.js
@@ -35,6 +35,7 @@ exports.jasmine = {
         boot: ['BOOT.js']
       },
       temp: 'path/to/temp/folder',
+      favicon: 'path/to/temp/folder/jasmine_favicon.png',
       options: {}
     };
 


### PR DESCRIPTION
Fixes #60 and #170.

 - Adds the `tempDir` option to the grunt config, and defaults to the original value `.grunt/grunt-contrib-jasmine`.
 - Only tries to delete the `.grunt` folder, but not the parents of a custom temp directory.
 - Adds the `favicon` path to the template context to keep the logic for joining paths out of the template.
 - Adds a test that uses a custom temp directory
   - Ensures the runner was loaded
   - Checks that the jasmine resources are being loaded from the custom directory
 - Documents the `tempDir` option
 - Provides an example
 - Updates the readme with the new documentation