### PR TITLE
fix(dependencies): Prevent npm from installing jasmine@2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "grunt-lib-phantomjs": "^1.0.0",
-    "jasmine-core": "^2.2.0",
+    "jasmine-core": "~2.4.0",
     "lodash": "~2.4.1",
     "rimraf": "^2.1.4",
     "sprintf-js": "~1.0.3"


### PR DESCRIPTION
Jasmine-core's newest minor version, 2.5.0, is causing tests to break. The previous release was 2.4.1. In package.json, I set the version to `~2.4.0`. 