### PR TITLE
Remove unnecessary options from phantomjs spawn call

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "grunt-lib-phantomjs": "^1.0.0",
-    "jasmine-core": "~2.4.0",
+    "jasmine-core": "2.5.2",
     "lodash": "~2.4.1",
     "rimraf": "^2.1.4",
     "sprintf-js": "~1.0.3"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "grunt-lib-phantomjs": "^1.0.0",
-    "jasmine-core": "2.5.2",
+    "jasmine-core": "2.2.0",
     "lodash": "~2.4.1",
     "rimraf": "^2.1.4",
     "sprintf-js": "~1.0.3"

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -140,6 +140,9 @@ module.exports = function(grunt) {
     grunt.verbose.subhead('Testing Jasmine specs via PhantomJS').or.writeln('Testing Jasmine specs via PhantomJS');
     grunt.log.writeln('');
 
+    // Delete Jasmine requirejs template options. (Windows Fix #254)
+    delete options.templateOptions;
+
     phantomjs.spawn(file, {
       failCode: 90,
       options: options,

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -141,7 +141,8 @@ module.exports = function(grunt) {
     grunt.log.writeln('');
 
     // Delete Jasmine requirejs template options. (Windows Fix #254)
-    delete options.templateOptions;
+    // Not working properly, need more investigation
+    // delete options.templateOptions;
 
     phantomjs.spawn(file, {
       failCode: 90,


### PR DESCRIPTION
When calling `phantomjs.spawn` we send the entire options obj. That can be huge for some projects and based on the docs of `grunt-lib-phantomjs` we only need 4 of them (there are actually more).

This is causing the module on Windows to crash with a `ENAMETOOLONG` error when the options obj is really big.

A example is when we send the PATHS key as part of `templateOptions` from Jasmine requirejs template.

If you have loads of files in that `paths` option it will fail as I said above.

This PR fixes that by removing templateOptions, but I guess we should remove everything we don't really need to send to phantom, or at least keep it in a different key as part of the config.