### PR TITLE
Fix deprecation warning in Node.js 7

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -153,7 +153,7 @@ module.exports = function(grunt) {
     removePhantomListeners();
 
     if (!options.keepRunner && fs.statSync(options.outfile).isFile()) {
-      fs.unlink(options.outfile);
+      fs.unlinkSync(options.outfile);
     }
 
     if (!options.keepRunner) {


### PR DESCRIPTION
Starting in Node.js v7.0.0, omitting the callback to async functions
emits a deprecation warning. Update the call to `fs.unlink` to instead
use `fs.unlinkSync`, which does not expect a callback.