### PR TITLE
Do not swallow errors silently

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -153,7 +153,7 @@ module.exports = function(grunt) {
     removePhantomListeners();
 
     if (!options.keepRunner && fs.statSync(options.outfile).isFile()) {
-      fs.unlink(options.outfile);
+      fs.unlinkSync(options.outfile);
     }
 
     if (!options.keepRunner) {


### PR DESCRIPTION
This switches to the sync unlink version to make sure errors are not silently swallowed. I can also implement it as the async version if that is requested.

This is long deprecated and will throw errors from Node.js 10.x on. See https://github.com/nodejs/node/pull/18668.