### PR TITLE
Delete outfile with fs.unlinkSync instead of fs.unlink

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -153,7 +153,7 @@ module.exports = function(grunt) {
     removePhantomListeners();
 
     if (!options.keepRunner && fs.statSync(options.outfile).isFile()) {
-      fs.unlink(options.outfile);
+      fs.unlinkSync(options.outfile);
     }
 
     if (!options.keepRunner) {


### PR DESCRIPTION
[`fs.unlink`](https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback) requires a callback as a second parameter, but [`fs.unlinkSync`](https://nodejs.org/api/fs.html#fs_fs_unlinksync_path) does not.

I believe this has been a problem for a while... Node 10 just started getting more complain-y about situations like this by throwing new JavaScript errors.

This addresses issue #266.