### PR TITLE
Deals with #274

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -134,7 +134,7 @@ module.exports = function(grunt) {
       }
       file = options.host + options.outfile;
     } else {
-      file = `file://${path.join(__dirname, '..', file)}`;
+      file = `file://${path.join(process.cwd(), file)}`;
     }
 
     const browser = await puppeteer.launch();


### PR DESCRIPTION
Rather then using `__dirname` (which is the directory of the current file) we use the current working directory of the process to find the spec runner file.