### PR TITLE
Create new optional 'noSandbox' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Default: `false`
 
 Display a list of all failed tests and their failure messages
 
+#### options.noSandbox
+Type: `Boolean`  
+Default: `false`
+
+Launching Puppeteer with --no-sandbox argument. (Fix [Debian issue](https://github.com/Googlechrome/puppeteer/issues/290))
+
 ### Flags
 
 Name: `build`

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -137,7 +137,7 @@ module.exports = function(grunt) {
       file = `file://${path.join(process.cwd(), file)}`;
     }
 
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({args: ['--no-sandbox']});
     grunt.log.subhead(`Testing specs with Jasmine/${options.version} via ${await browser.version()}`);
     const page = await browser.newPage();
 

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -137,7 +137,13 @@ module.exports = function(grunt) {
       file = `file://${path.join(process.cwd(), file)}`;
     }
 
-    const browser = await puppeteer.launch({args: ['--no-sandbox']});
+    let puppeteerLaunchSetting;
+    if(options.hasOwnProperty('noSandbox') && options.noSandbox){
+        puppeteerLaunchSetting = {args: ['--no-sandbox']};
+        delete options.noSandbox;
+    }
+
+    const browser = await puppeteer.launch(puppeteerLaunchSetting);
     grunt.log.subhead(`Testing specs with Jasmine/${options.version} via ${await browser.version()}`);
     const page = await browser.newPage();
 


### PR DESCRIPTION
- create new optional 'noSandbox' option to launch Puppeteer with --no-sandbox argument. It solves Debian Puppeteer launch issue (https://github.com/Googlechrome/puppeteer/issues/290)
- write down the doc