### PR TITLE
Fix the timing issue between installing jasmine and launching headless chrome

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -97,17 +97,20 @@ module.exports = function(grunt) {
       grunt.log.debug(options);
     }
 
+    var done = this.async();
+
     // The filter returned no spec files so skip headless.
-    if (!jasmine.buildSpecrunner(this.filesSrc, options)) {
+    if (!(await jasmine.buildSpecrunner(this.filesSrc, options))) {
+      done(false);
       return;
     }
 
     // If we're just building (e.g. for web), skip headless.
     if (this.flags.build) {
+      done(false);
       return;
     }
 
-    var done = this.async();
     const err = await launchPuppeteer(options);
     var success = !err && status.failed === 0;
 

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -56,7 +56,7 @@ exports.init = function(grunt) {
     try {
       jasmineRequire = require(path.join(process.cwd(), jasmineCoreFolder));
     } catch (error) {
-      grunt.log.error(`Jasmine version: ${options.verion} does not exist in npm!`);
+      grunt.log.error(`Jasmine version: ${options.version} does not exist in npm!`);
       grunt.fail.fatal(error);
     }
 


### PR DESCRIPTION
When you are running tests the first time, you might encounter the following error. It's because we didn't wait for jasmine installation to finish before launching chrome.

```
function bold() { [native code] }
>> Error caught from Puppeteer
Warning: Error: net::ERR_FILE_NOT_FOUND at file:///_SpecRunner.html
  at navigate (/node_modules/puppeteer/lib/Page.js:539:37)
  at <anonymous>:null:null
  at process._tickCallback (internal/process/next_tick.js:188:7)
 Use --force to continue.
```