### PR TITLE
fix: build only should pass if the buildSpecrunner runs without error

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -107,7 +107,7 @@ module.exports = function(grunt) {
 
     // If we're just building (e.g. for web), skip headless.
     if (this.flags.build) {
-      done(false);
+      done(true);
       return;
     }
 


### PR DESCRIPTION
Before this PR, when you ran the task as build only, it failed every time.

![image](https://user-images.githubusercontent.com/1326248/48081994-9bd84080-e1ae-11e8-9cf7-c59b8df1f11a.png)
