### PR TITLE
moved resolveJasmine/jasminePromise function to fix scope issue

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -26,11 +26,6 @@ module.exports = function(grunt) {
 
   var status = {};
 
-  let resolveJasmine;
-  const jasminePromise = new Promise((resolve) => {
-    resolveJasmine = resolve;
-  });
-
   var symbols = {
     none: {
       check: '',
@@ -150,8 +145,14 @@ module.exports = function(grunt) {
     grunt.log.subhead(`Testing specs with Jasmine/${options.version} via ${await browser.version()}`);
     const page = await browser.newPage();
 
+
+    let resolveJasmine;
+    const jasminePromise = new Promise((resolve) => {
+      resolveJasmine = resolve;
+    });
+
     try {
-      await setup(options, page);
+      await setup(options, page, resolveJasmine);
       await page.goto(file, { waitUntil: 'domcontentloaded' });
 
       await jasminePromise;
@@ -178,7 +179,7 @@ module.exports = function(grunt) {
     }
   }
 
-  async function setup(options, page) {
+  async function setup(options, page, resolveJasmine) {
     var indentLevel = 1,
       tabstop = 2,
       thisRun = {},


### PR DESCRIPTION
This PR relates to [issue 299](https://github.com/gruntjs/grunt-contrib-jasmine/issues/299)

Upon further inspection I noticed that the function that is awaited until the jasmine tests complete is defined closer to the top of the file where I don't believe it is getting properly reset between multi tasks, causing the strange behavior I observed. 

I've simply moved that function definition into the `launchPuppeteer` function and explicitly pass it into the `setup` function, and this seems to fix the issue.