### PR TITLE
grunt-contrib-jasmine: Resolved Jasmine Test Hang Issue

### DIFF
--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
   let resolveJasmine;
   const jasminePromise = new Promise((resolve) => {
     resolveJasmine = resolve;
+    resolve();
   });
 
   var symbols = {


### PR DESCRIPTION
Testcases which use grunt-contrib-jasmine are hanging because jasmine doesn't get test status back from the browser.

So added ```resolve();``` in jasmine.js to resolve the jasmine test case hang issue.
