### PR TITLE
apply un-used custom timeout value and update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ Default: `false`
 
 Display a list of all failed tests and their failure messages
 
+#### options.allowFileAccess
+Type: `Boolean`
+Default: `false`
+
+Launches puppeteer with --allow-file-access-from-files (Fix Issue https://github.com/gruntjs/grunt-contrib-jasmine/issues/298)
+
+#### options.timeout
+Type: `Number`
+Default: `30000`
+
+Change the puppeteer default timeout value in milliseconds (reference: https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaulttimeouttimeout)
+
 ### Flags
 
 Name: `build`

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
     // Merge task-specific options with these defaults.
     var options = this.options({
       version: 'latest',
-      timeout: 10000,
+      timeout: 30000,
       styles: [],
       specs: [],
       helpers: [],
@@ -165,6 +165,7 @@ module.exports = function(grunt) {
 
     try {
       await setup(options, dispatcher, page);
+      page.setDefaultTimeout(options.timeout);
       await page.goto(file, { waitUntil: 'domcontentloaded' });
 
       await jasminePromise;


### PR DESCRIPTION
I found there's an un-used option `timeout` in the option list. In our project, we have an expected long waiting time when testing (ex: load a large script file), and want to custom the timeout value when testing.

Here's what I did:
1. apply un-used custom `timeout` value in `page.setDefaultTimeout(timeout)` after setup
2. set the default option timeout value to 30 secs to sync with puppeteer's deafult timeout value.
 So, this change won't affect existing user's tests running
3. update readme file to add timeout option description
4. add back an accidentally removed(I believe) `allowFileAccess` option content in readme file (in this PR: https://github.com/gruntjs/grunt-contrib-jasmine/pull/306)

reference: https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagesetdefaulttimeouttimeout
The `setDefaultTimeout` will change the default maximum time for the following methods and related shortcuts:
page.goBack([options])
page.goForward([options])
page.goto(url[, options])
page.reload([options])
page.setContent(html[, options])
page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
page.waitForFileChooser([options])
page.waitForFunction(pageFunction[, options[, ...args]])
page.waitForNavigation([options])
page.waitForRequest(urlOrPredicate[, options])
page.waitForResponse(urlOrPredicate[, options])
page.waitForSelector(selector[, options])
page.waitForXPath(xpath[, options])

Thank you.