### PR TITLE
bump puppeteer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-eslint": "^22.0.0",
     "lodash": "^4.17.15",
     "pacote": "^9.5.4",
-    "puppeteer": "^8.0.0",
+    "puppeteer": "^19.2.0",
     "rimraf": "^2.6.3",
     "sprintf-js": "^1.1.2"
   },


### PR DESCRIPTION
Potentially fixes:
https://github.com/gruntjs/grunt-contrib-jasmine/issues/349
https://github.com/gruntjs/grunt-contrib-jasmine/issues/339

We saw similar issues and ruled it down to puppeteer\chrome. Problem gone away with upgraded puppeteer version